### PR TITLE
Upload film

### DIFF
--- a/CloudCinemaBack/functions/clean_up_failed_upload.py
+++ b/CloudCinemaBack/functions/clean_up_failed_upload.py
@@ -1,0 +1,30 @@
+import traceback
+import os
+import boto3
+
+movie_table_name = os.environ['MOVIE_TABLE_NAME']
+task_token_table_name = os.environ['TASK_TOKEN_TABLE_NAME']
+dynamodb = boto3.resource('dynamodb')
+
+def clean_up_failed_upload(event, context):
+    try:
+        id = event['movieDetails']['id']
+        timestamp = int(event['movieDetails']['timestamp'])
+        task_token_table = dynamodb.Table(task_token_table_name)
+        movie_table = dynamodb.Table(movie_table_name)
+
+        task_token_table.delete_item(Key={
+            'movieId': id
+        })
+
+        movie_table.delete_item(Key={
+            'id': id,
+            'timestamp': timestamp
+        })
+
+        return
+    except Exception as e:
+        print("#EXCEPTION")
+        print(e)
+        print(traceback.format_exc())
+        raise e

--- a/CloudCinemaBack/functions/get_movie.py
+++ b/CloudCinemaBack/functions/get_movie.py
@@ -9,19 +9,17 @@ bucket_name = os.environ['BUCKET_NAME']
 s3 = boto3.client('s3')
 
 def get_one(event, context):
-    # TODO: Make this lambda send a redirect to a S3 presigned url from which the movie will be downloaded
     try:
         movie_name = event['pathParameters']['movie_name']
-        response = s3.get_object(Bucket=bucket_name, Key=movie_name)
-        data = response['Body'].read()
+        presigned_url = s3.generate_presigned_url('get_object', Params={
+            'Bucket': bucket_name,
+            'Key': movie_name
+        }, ExpiresIn=3600, HttpMethod="GET")
         return {
-            'statusCode': 200,
+            'statusCode': 302,
             'headers': {
-                'Content-Type': 'video/mp4',
-                'Content-Disposition': f'attachment; filename="{movie_name}"'
+                'Location': presigned_url,
             },
-            'body':  base64.b64encode(data).decode('utf-8'),
-            'isBase64Encoded': True 
         }
     except Exception as e:
         return {

--- a/CloudCinemaBack/functions/get_movie.py
+++ b/CloudCinemaBack/functions/get_movie.py
@@ -9,6 +9,7 @@ bucket_name = os.environ['BUCKET_NAME']
 s3 = boto3.client('s3')
 
 def get_one(event, context):
+    # TODO: Make this lambda send a redirect to a S3 presigned url from which the movie will be downloaded
     try:
         movie_name = event['pathParameters']['movie_name']
         response = s3.get_object(Bucket=bucket_name, Key=movie_name)

--- a/CloudCinemaBack/functions/is_movie_uploaded.py
+++ b/CloudCinemaBack/functions/is_movie_uploaded.py
@@ -1,0 +1,27 @@
+import traceback
+import os
+import boto3
+
+bucket_name = os.environ['BUCKET_NAME']
+table_name = os.environ['TABLE_NAME']
+dynamodb = boto3.resource('dynamodb')
+s3 = boto3.client('s3')
+step_functions = boto3.client('stepfunctions')
+
+def is_movie_uploaded(event, context):
+    try:
+        id = event['movieDetails']['id']
+        task_token = event['taskToken']
+
+        task_token_table = dynamodb.Table(table_name)
+        task_token_table.put_item(
+            Item={
+                'movieId': id,
+                'taskToken': task_token
+            }
+        )
+
+    except Exception as e:
+        print("#EXCEPTION")
+        print(e)
+        print(traceback.format_exc())

--- a/CloudCinemaBack/functions/mark_movie_as_uploaded.py
+++ b/CloudCinemaBack/functions/mark_movie_as_uploaded.py
@@ -1,0 +1,29 @@
+import traceback
+import os
+import boto3
+
+movie_table_name = os.environ['TABLE_NAME']
+dynamodb = boto3.resource('dynamodb')
+
+def mark_movie_as_uploaded(event, context):
+    try:
+        id = event['movieDetails']['id']
+        timestamp = int(event['movieDetails']['timestamp'])
+        movie_table = dynamodb.Table(movie_table_name)
+
+        movie_table.update_item(
+            Key={
+                'id': id,
+                'timestamp': timestamp
+            },
+            UpdateExpression="set pending = :p",
+            ExpressionAttributeValues={":p": False},
+            ReturnValues="UPDATED_NEW",
+        )
+
+        return
+    except Exception as e:
+        print("#EXCEPTION")
+        print(e)
+        print(traceback.format_exc())
+        raise e

--- a/CloudCinemaBack/functions/send_movie_upload_task_result.py
+++ b/CloudCinemaBack/functions/send_movie_upload_task_result.py
@@ -1,0 +1,35 @@
+import traceback
+import os
+import boto3
+
+bucket_name = os.environ['BUCKET_NAME']
+table_name = os.environ['TABLE_NAME']
+dynamodb = boto3.resource('dynamodb')
+s3 = boto3.client('s3')
+step_functions = boto3.client('stepfunctions')
+
+def send_movie_upload_task_result(event, context):
+    try:
+        id = event['Records'][0]['s3']['object']['key']
+
+        task_token_table = dynamodb.Table(table_name)
+        task_token = task_token_table.get_item(
+            Key={
+                'movieId': id
+            }
+        )
+
+        step_functions.send_task_success(
+            taskToken=task_token['Item']['taskToken'],
+            output='{"movieId": "' + id + '"}'
+        )
+
+        task_token_table.delete_item(
+            Key={
+                'movieId': id
+            }
+        )
+    except Exception as e:
+        print("#EXCEPTION")
+        print(e)
+        print(traceback.format_exc())

--- a/CloudCinemaBack/functions/start_movie_upload.py
+++ b/CloudCinemaBack/functions/start_movie_upload.py
@@ -1,0 +1,66 @@
+import traceback
+import json
+import uuid
+import time
+import os
+import boto3
+import base64
+
+
+
+bucket_name = os.environ['BUCKET_NAME']
+table_name = os.environ['TABLE_NAME']
+dynamodb = boto3.resource('dynamodb')
+s3 = boto3.client('s3')
+
+def start_movie_upload(event, context):
+    try:
+        request_body = json.loads(base64.b64decode(event['body']).decode('utf-8'))
+        name = request_body['name']
+        timestamp = int(time.time())
+        director = request_body['director']
+        actors = request_body['actors']
+        year = request_body['year']
+        id = uuid.uuid4()
+
+        table = dynamodb.Table(table_name)
+        # Put item into table
+        response = table.put_item(
+            Item={
+                'id': str(id),
+                'name': name,
+                'director': director,
+                'actors': actors,
+                'year': year,
+                'timestamp': timestamp,
+                'pending': True
+            }
+        )
+
+        presigned_url = s3.generate_presigned_url('put_object', Params={
+            'Bucket': bucket_name,
+            'Key': str(id),
+            "Expires": 3600
+        }, HttpMethod="put")
+
+        request_body['id'] = id
+        response_body = {
+                'movie': json.dumps(request_body, default=str),
+                'uploadUrl': presigned_url
+
+        }
+        return {
+            'statusCode': 201,
+            'body': json.dumps(response_body, default=str),
+            'isBase64Encoded': False 
+        }
+    except Exception as e:
+        print('##EXCEPTION')
+        print(e)
+        print(traceback.format_exc())
+        print('#BODY')
+        print(event['body'])
+        return {
+            'statusCode': 500,
+            'body': 'Error: {}'.format(str(e))
+        }

--- a/CloudCinemaBack/lib/cloud_cinema_back-stack.ts
+++ b/CloudCinemaBack/lib/cloud_cinema_back-stack.ts
@@ -23,6 +23,11 @@ export class CloudCinemaBackStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true
     });
+    bucket.addCorsRule({
+      allowedOrigins: ['http://localhost:4200/'], // Dozvoljava pristup sa localhost-a
+      allowedMethods: [s3.HttpMethods.GET], // Dozvoljava samo GET zahteve
+      allowedHeaders: ['*'] // Dozvoljava sva zaglavlja
+    });
 
     const movie_info_table = new dynamodb.Table(this, 'CloudCinemaMovieInfoTable', {
       tableName: 'cloud-cinema-movie-info', 

--- a/CloudCinemaBack/lib/movie_upload_step_function.ts
+++ b/CloudCinemaBack/lib/movie_upload_step_function.ts
@@ -1,0 +1,121 @@
+import * as cdk from 'aws-cdk-lib';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import path = require('path');
+
+export interface MovieUploadStepFunctionProps {
+    movieSourceBucket: s3.Bucket,
+    movieTable: Table
+}
+
+export class MovieUploadStepFunction extends Construct {
+    public readonly stateMachine: sfn.StateMachine;
+    public readonly isMovieUploaded: lambda.Function;
+    public readonly cleanUpFailedUpload: lambda.Function;
+    public readonly markMovieAsUploaded: lambda.Function;
+
+    constructor(scope: Construct, id: string, props: MovieUploadStepFunctionProps) {
+        super(scope, id);
+        const movieTable = props.movieTable;
+        const movieSourceBucket = props.movieSourceBucket;
+
+        const task_token_table = new dynamodb.Table(this, 'MovieUploadTaskTokenTable', {
+            tableName: 'movie-upload-task-token-table', 
+            partitionKey: { name: 'movieId', type: dynamodb.AttributeType.STRING},
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+            readCapacity:1,            //u grupi pise da treba da se stave read i write na 1 da ne bi naplacivao
+            writeCapacity:1
+        });               
+
+        // Define Lambdas
+        this.isMovieUploaded = new lambda.Function(this, 'IsMovieUploadedFunction', {
+            runtime: lambda.Runtime.PYTHON_3_9,
+            handler: 'is_movie_uploaded.is_movie_uploaded', 
+            code: lambda.Code.fromAsset(path.join(__dirname,'../functions')),
+            timeout: cdk.Duration.seconds(30)
+        });
+        this.cleanUpFailedUpload = new lambda.Function(this, 'CleanUpOrphanedMovieDetailsAndTaskTokenFunction', {
+            runtime: lambda.Runtime.PYTHON_3_9,
+            handler: 'clean_up_failed_upload.clean_up_failed_upload', 
+            code: lambda.Code.fromAsset(path.join(__dirname,'../functions')),
+            timeout: cdk.Duration.seconds(30)
+        });
+        this.markMovieAsUploaded = new lambda.Function(this, 'MarkMovieAsUploadedFunction', {
+            runtime: lambda.Runtime.PYTHON_3_9,
+            handler: 'mark_movie_as_uploaded.mark_movie_as_uploaded', 
+            code: lambda.Code.fromAsset(path.join(__dirname,'../functions')),
+            timeout: cdk.Duration.seconds(30)
+        });
+
+        const sendMovieUploadTaskResult = new lambda.Function(this, 'SendMovieUploadTaskResultFunction', {
+            runtime: lambda.Runtime.PYTHON_3_9,
+            handler: 'send_movie_upload_task_result.send_movie_upload_task_result', 
+            code: lambda.Code.fromAsset(path.join(__dirname,'../functions')),
+            timeout: cdk.Duration.seconds(30)
+        });
+
+
+        // Grant permissions to lambdas
+        movieSourceBucket.grantRead(this.isMovieUploaded);
+        task_token_table.grantWriteData(this.isMovieUploaded);
+        this.isMovieUploaded.addEnvironment('BUCKET_NAME', movieSourceBucket.bucketName);
+        this.isMovieUploaded.addEnvironment('TABLE_NAME', task_token_table.tableName);
+
+        task_token_table.grantReadWriteData(this.cleanUpFailedUpload);
+        movieTable.grantReadWriteData(this.cleanUpFailedUpload)
+        this.cleanUpFailedUpload.addEnvironment('MOVIE_TABLE_NAME', movieTable.tableName);
+        this.cleanUpFailedUpload.addEnvironment('TASK_TOKEN_TABLE_NAME', task_token_table.tableName);
+
+        movieTable.grantReadWriteData(this.markMovieAsUploaded);
+        this.markMovieAsUploaded.addEnvironment('TABLE_NAME', movieTable.tableName);
+
+        sendMovieUploadTaskResult.addEnvironment('BUCKET_NAME', movieSourceBucket.bucketName)
+        sendMovieUploadTaskResult.addEnvironment('TABLE_NAME', task_token_table.tableName);
+
+
+        // Define step function
+        const definition = new tasks.LambdaInvoke(this, 'IsMovieUploadedTask', {
+            lambdaFunction: this.isMovieUploaded,
+            integrationPattern: sfn.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
+            payload: sfn.TaskInput.fromObject({
+                taskToken: sfn.JsonPath.taskToken,
+                'movieDetails.$': '$',
+            }),
+            taskTimeout: sfn.Timeout.duration(cdk.Duration.minutes(1)),
+            resultPath: '$.taskResult'
+        });
+        const cleanUpFailedUploadTask = new tasks.LambdaInvoke(this, 'CleanUpOrphanedMovieDetailsAndTaskTokenTask', {
+            lambdaFunction: this.cleanUpFailedUpload,
+            payload: sfn.TaskInput.fromObject({
+                'movieDetails.$': '$',
+            }),
+        }).next(new sfn.Fail(this, 'UploadFail'));
+        definition.addCatch(cleanUpFailedUploadTask, {
+            resultPath: "$.movieDetails"
+        });
+
+        const markMovieAsUploadedTask = new tasks.LambdaInvoke(this, 'MarkMovieAsUploadedTask', {
+            lambdaFunction: this.markMovieAsUploaded,
+            payload: sfn.TaskInput.fromObject({
+                'movieDetails.$': '$',
+            }),
+            resultPath: '$.taskResult'
+        });
+        definition.next(
+            markMovieAsUploadedTask
+        );
+
+        this.stateMachine = new sfn.StateMachine(this, 'MovieUploadStateMachine', {
+            definitionBody: sfn.DefinitionBody.fromChainable(definition)
+        });
+        movieSourceBucket.addEventNotification(s3.EventType.OBJECT_CREATED, new LambdaDestination(sendMovieUploadTaskResult));
+        this.stateMachine.grantTaskResponse(sendMovieUploadTaskResult);
+        task_token_table.grantReadWriteData(sendMovieUploadTaskResult)
+    }
+}


### PR DESCRIPTION
This PR adds a feature that allows users to upload movies and information about them.
To ensure that there are no movies for which a corresponding file in S3 does not exist, a step function sets the `pending` column of a movie to false once a file with the correct name appears in S3. 
This PR also changes the `get_movie` lambda function to redirect to a presigned S3 URL instead of delivering the movie directly.